### PR TITLE
added citation-label fallback for entries without authors

### DIFF
--- a/biblatex.csl
+++ b/biblatex.csl
@@ -62,10 +62,17 @@
     </choose>
   </macro>
   <macro name="citeKey">
-    <group>
-      <text macro="author-short" text-case="lowercase"/>
-      <text macro="issued-year"/>
-    </group>
+    <choose>
+      <if variable="author">
+        <group>
+          <text macro="author-short" text-case="lowercase"/>
+          <text macro="issued-year"/>
+        </group>
+      </if>
+      <else>
+        <text variable="citation-label"/>
+      </else>
+    </choose>
   </macro>
   <macro name="author-short">
     <names variable="author">

--- a/biblatex.csl
+++ b/biblatex.csl
@@ -22,9 +22,14 @@
       <email>ds858@cam.ac.uk</email>
       <uri>https://dstrohmaier.com</uri>
     </contributor>
+    <contributor>
+      <name>Jack Bosco</name>
+      <email>joseph.bosco@columbia.edu</email>
+      <uri>https://jackbosco.github.io/Website_static</uri>
+    </contributor>
     <category citation-format="label"/>
     <category field="generic-base"/>
-    <updated>2023-01-22T11:14:57+00:00</updated>
+    <updated>2025-07-24T22:15:50+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="zotero2biblatexType">


### PR DESCRIPTION
# Fix: Use citation-label fallback for entries without authors

## Problem
The current biblatex.csl always uses the `author-short` macro for citation keys, which can produce inconsistent or problematic keys when no author is present, relying on complex substitution logic through editor, translator, and title fields.

## Solution
This PR implements a simpler, more reliable approach using CSL's built-in `citation-label` variable as a fallback.

### Key Changes
1. **Added conditional logic** to the `citeKey` macro:
   - **When author exists**: Uses existing `author-short` + year pattern
   - **When no author**: Falls back to `citation-label` variable

2. **Simplified fallback mechanism**:
   - Removes dependency on complex author-short substitutions for non-author entries
   - Leverages CSL's standard `citation-label` field for consistent key generation

### Code Changes
```xml
<macro name="citeKey">
  <choose>
    <if variable="author">
      <group>
        <text macro="author-short" text-case="lowercase"/>
        <text macro="issued-year"/>
      </group>
    </if>
    <else>
      <text variable="citation-label"/>
    </else>
  </choose>
</macro>